### PR TITLE
docs: Add hermes-memorex plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Hermes Agent is an open-source, self-improving AI agent with persistent memory, 
 - [chainlink-agent-skills](https://github.com/smartcontractkit/chainlink-agent-skills) - Official Chainlink integration skills for blockchain oracle interactions.
 - [evey-bridge-plugin](https://github.com/42-evey/evey-bridge-plugin) - Plugin bridging Claude Code and Hermes Agent for cross-tool workflows.
 - [execplan-skill](https://github.com/tiann/execplan-skill) - Complex task execution skill with checkpoints and failure recovery.
+- [hermes-memorex](https://github.com/somto8720/hermes-memorex) - Memory visualization, graph explorer, and skill evolution dashboard plugin.
 - [hermes-plugins](https://github.com/42-evey/hermes-plugins) - Collection of plugins for goal management, model selection, and cost control.
 - [hermes-weather-plugin](https://github.com/FahrenheitResearch/hermes-weather-plugin) - Professional-grade weather data plugin using NWS and NEXRAD radar sources.
 - [litprog-skill](https://github.com/tlehman/litprog-skill) - Literate programming skill for generating well-documented executable code.


### PR DESCRIPTION
Adding the \hermes-memorex\ plugin to the Skills and Plugins section. This is a zero-dependency local SPA dashboard for memory visualization, graph exploration, and skill evolution tracking.