### PR TITLE
Add OneQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Hermes Agent is an open-source, self-improving AI agent with persistent memory, 
 - [Showcase Projects](#showcase-projects)
 - [Tutorials and Guides](#tutorials-and-guides)
 - [Community](#community)
+- [Related Lists](#related-lists)
 
 ## Official Resources
 
@@ -48,7 +49,7 @@ Hermes Agent is an open-source, self-improving AI agent with persistent memory, 
 
 - [Anthropic-Cybersecurity-Skills](https://github.com/mukul975/Anthropic-Cybersecurity-Skills) - Over 700 cybersecurity skills mapped to the MITRE ATT&CK framework.
 - [black-forest-labs/skills](https://github.com/black-forest-labs/skills) - Official FLUX image generation skills for agent-driven visual content creation.
-- [chainlink-agent-skills](https://github.com/smartcontractkit/chainlink-agent-skills) - Official Chainlink integration skills for Blockchain oracle interactions.
+- [chainlink-agent-skills](https://github.com/smartcontractkit/chainlink-agent-skills) - Official Chainlink integration skills for blockchain oracle interactions.
 - [evey-bridge-plugin](https://github.com/42-evey/evey-bridge-plugin) - Plugin bridging Claude Code and Hermes Agent for cross-tool workflows.
 - [execplan-skill](https://github.com/tiann/execplan-skill) - Complex task execution skill with checkpoints and failure recovery.
 - [hermes-plugins](https://github.com/42-evey/hermes-plugins) - Collection of plugins for goal management, model selection, and cost control.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Hermes Agent is an open-source, self-improving AI agent with persistent memory, 
 - [hermes-plugins](https://github.com/42-evey/hermes-plugins) - Collection of plugins for goal management, model selection, and cost control.
 - [hermes-weather-plugin](https://github.com/FahrenheitResearch/hermes-weather-plugin) - Professional-grade weather data plugin using NWS and NEXRAD radar sources.
 - [litprog-skill](https://github.com/tlehman/litprog-skill) - Literate programming skill for generating well-documented executable code.
-- [OneQuery](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable queries for agents against approved data sources. `Beta`.
+- [OneQuery](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable queries for agents against approved data sources. `Production`.
 - [pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) - Pydantic AI integration with agentskills.io skill validation and discovery.
 - [Skills Guide](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) - Official documentation for creating, publishing, and discovering skills.
 - [wondelai/skills](https://github.com/wondelai/skills) - Cross-platform agent skills collection compatible with multiple agent frameworks.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Hermes Agent is an open-source, self-improving AI agent with persistent memory, 
 - [hermes-plugins](https://github.com/42-evey/hermes-plugins) - Collection of plugins for goal management, model selection, and cost control.
 - [hermes-weather-plugin](https://github.com/FahrenheitResearch/hermes-weather-plugin) - Professional-grade weather data plugin using NWS and NEXRAD radar sources.
 - [litprog-skill](https://github.com/tlehman/litprog-skill) - Literate programming skill for generating well-documented executable code.
-- [OneQuery](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable agent queries against approved data sources. `Beta`.
+- [OneQuery](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable queries for agents against approved data sources. `Beta`.
 - [pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) - Pydantic AI integration with agentskills.io skill validation and discovery.
 - [Skills Guide](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) - Official documentation for creating, publishing, and discovering skills.
 - [wondelai/skills](https://github.com/wondelai/skills) - Cross-platform agent skills collection compatible with multiple agent frameworks.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Hermes Agent is an open-source, self-improving AI agent with persistent memory, 
 - [Showcase Projects](#showcase-projects)
 - [Tutorials and Guides](#tutorials-and-guides)
 - [Community](#community)
-- [Related Lists](#related-lists)
 
 ## Official Resources
 
@@ -49,7 +48,7 @@ Hermes Agent is an open-source, self-improving AI agent with persistent memory, 
 
 - [Anthropic-Cybersecurity-Skills](https://github.com/mukul975/Anthropic-Cybersecurity-Skills) - Over 700 cybersecurity skills mapped to the MITRE ATT&CK framework.
 - [black-forest-labs/skills](https://github.com/black-forest-labs/skills) - Official FLUX image generation skills for agent-driven visual content creation.
-- [chainlink-agent-skills](https://github.com/smartcontractkit/chainlink-agent-skills) - Official Chainlink integration skills for blockchain oracle interactions.
+- [chainlink-agent-skills](https://github.com/smartcontractkit/chainlink-agent-skills) - Official Chainlink integration skills for Blockchain oracle interactions.
 - [evey-bridge-plugin](https://github.com/42-evey/evey-bridge-plugin) - Plugin bridging Claude Code and Hermes Agent for cross-tool workflows.
 - [execplan-skill](https://github.com/tiann/execplan-skill) - Complex task execution skill with checkpoints and failure recovery.
 - [hermes-plugins](https://github.com/42-evey/hermes-plugins) - Collection of plugins for goal management, model selection, and cost control.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Hermes Agent is an open-source, self-improving AI agent with persistent memory, 
 - [hermes-plugins](https://github.com/42-evey/hermes-plugins) - Collection of plugins for goal management, model selection, and cost control.
 - [hermes-weather-plugin](https://github.com/FahrenheitResearch/hermes-weather-plugin) - Professional-grade weather data plugin using NWS and NEXRAD radar sources.
 - [litprog-skill](https://github.com/tlehman/litprog-skill) - Literate programming skill for generating well-documented executable code.
-- [OneQuery](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - Agent-ready CLI/skill for bounded, auditable queries against approved data sources through centralized credentials, read-only validation, limits, and audit logs. `Beta`.
+- [OneQuery](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable agent queries against approved data sources. `Beta`.
 - [pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) - Pydantic AI integration with agentskills.io skill validation and discovery.
 - [Skills Guide](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) - Official documentation for creating, publishing, and discovering skills.
 - [wondelai/skills](https://github.com/wondelai/skills) - Cross-platform agent skills collection compatible with multiple agent frameworks.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Hermes Agent is an open-source, self-improving AI agent with persistent memory, 
 - [hermes-plugins](https://github.com/42-evey/hermes-plugins) - Collection of plugins for goal management, model selection, and cost control.
 - [hermes-weather-plugin](https://github.com/FahrenheitResearch/hermes-weather-plugin) - Professional-grade weather data plugin using NWS and NEXRAD radar sources.
 - [litprog-skill](https://github.com/tlehman/litprog-skill) - Literate programming skill for generating well-documented executable code.
+- [OneQuery](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - Agent-ready CLI/skill for bounded, auditable queries against approved data sources through centralized credentials, read-only validation, limits, and audit logs. `Beta`.
 - [pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) - Pydantic AI integration with agentskills.io skill validation and discovery.
 - [Skills Guide](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) - Official documentation for creating, publishing, and discovering skills.
 - [wondelai/skills](https://github.com/wondelai/skills) - Cross-platform agent skills collection compatible with multiple agent frameworks.


### PR DESCRIPTION
## Checklist

- [x] Link returns 200 OK
- [x] Entry is in alphabetical order within its category
- [x] Description starts with uppercase and ends with a period
- [ ] npx awesome-lint passes locally
- [x] Not a duplicate of an existing entry
- [x] Maturity level is indicated in the description

## What does this resource do?

Adds OneQuery to Skills and Plugins.

OneQuery is a CLI skill for safe, auditable queries for agents against approved data sources.

## Maturity

Marked as `Production` in the README entry because the contribution guidelines for this repository ask entries to include a maturity indicator in the description. I used `Production` after checking tagged releases, documented CLI usage, and recent maintenance. Verified with:

- `gh release list --repo wordbricks/onequery --limit 10`
- `gh repo view wordbricks/onequery --json pushedAt,createdAt,description,url,stargazerCount,licenseInfo`

## Validation

- `mise exec -- npx -y awesome-lint`

The lint run fails on existing README issues unrelated to this entry:

- `README.md:22:1` - ToC should not contain section `Related Lists`
- `README.md:52:87` - `blockchain` spell-check warning

## Disclosure

I am affiliated with Wordbricks/OneQuery.