### PR TITLE
Add Sequenzy skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Hermes Agent is an open-source, self-improving AI agent with persistent memory, 
 - [hermes-weather-plugin](https://github.com/FahrenheitResearch/hermes-weather-plugin) - Professional-grade weather data plugin using NWS and NEXRAD radar sources.
 - [litprog-skill](https://github.com/tlehman/litprog-skill) - Literate programming skill for generating well-documented executable code.
 - [pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) - Pydantic AI integration with agentskills.io skill validation and discovery.
+- [Sequenzy/skills](https://github.com/Sequenzy/skills/tree/main/skills/sequenzy-email-marketing) - Sequenzy email marketing and transactional/product email skill for operating subscribers, segments, campaigns, sequences, templates, stats, and transactional sends from Hermes-compatible agents. `Beta`.
 - [Skills Guide](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) - Official documentation for creating, publishing, and discovering skills.
 - [wondelai/skills](https://github.com/wondelai/skills) - Cross-platform agent skills collection compatible with multiple agent frameworks.
 


### PR DESCRIPTION
Adds Sequenzy's installable email marketing skill to the Skills and Plugins section.

The skill is directly relevant to the agentskills.io/Hermes-compatible ecosystem, is public, maintained, and includes a concrete workflow for operating subscribers, segments, campaigns, sequences, templates, stats, and transactional sends from an agent.

Verification:
- Ran `git diff --check`.
- Ran `npx -y awesome-lint`: only existing repository issues remain (`Related Lists` ToC mismatch and the existing `blockchain` spell-check warning). The Sequenzy entry's punctuation issue was fixed in the latest commit.