### PR TITLE
Add Hermes-OTG (portable USB Hermes Agent) to Deployment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Hermes Agent is an open-source, self-improving AI agent with persistent memory, 
 
 - [evey-setup](https://github.com/42-evey/evey-setup) - One-command setup script for a full Hermes Agent development stack.
 - [hermes-agent-docker](https://github.com/xmbshwll/hermes-agent-docker) - Minimal Docker sandbox environment for isolated Hermes Agent instances.
+- [Hermes-OTG](https://github.com/MilkyWay008/Hermes-OTG) - Portable, zero-install Hermes Agent on a USB stick; runs side-by-side with an installed Hermes desktop, works offline, and survives drive-letter changes. The rescue kit for broken host installs.
 - [nix-hermes-agent](https://github.com/0xrsydn/nix-hermes-agent) - Nix package and NixOS module for reproducible Hermes Agent installations.
 - [portainer-stack-hermes](https://github.com/ellickjohnson/portainer-stack-hermes) - Docker Compose stack with Portainer management UI and ttyd web terminal.
 


### PR DESCRIPTION
Add **Hermes-OTG** to the Deployment section — a portable, zero-install Hermes Agent on a USB stick.

**The pitch:**
> Your Hermes/OpenClaw update just broke — what do you do? Plug in a USB stick and run the full agent anyway. Hermes OTG: zero install, instant run, diagnose & fix your host in no time — even side-by-side with your installed Hermes desktop. The rescue kit for broken host installs.

**Why it's awesome:**
> The first portable Hermes that does all of it — full desktop app from hot-swappable USB, source-patched (not launcher-hack) portability, offline deploy; no admin rights, no host pollution. Pair it with Windows-to-Go and a dead PC becomes a working machine again — an AI rescue tech disguised as a supercharged Hiren's BootCD. Dream come true for sysadmins & network engineers.

**Supply chain note:** SECURITY.md (component provenance, pinned versions, private vuln reporting via GitHub) + SHA256SUMS committed to the repo root; GitHub records release asset digests independently.

One-line list entry, alphabetized in the Deployment section.